### PR TITLE
Search for compile_commands.json in out-of-source builds

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -239,7 +239,7 @@ function! LoadUserOptions()
     endif
     if l:source == 'path'
       call s:parsePathOption()
-    elseif l:source == 'compile_commands.json'
+    elseif l:source =~# 'compile_commands.json'
       call s:findCompilationDatase(l:source)
     elseif l:source == '.clang_complete'
       call s:parseConfig()


### PR DESCRIPTION
This is done by loosening the match for the 'compile_commands.json' option in clang_auto_user_option
The goal is to allow prefixing the compile_commands.json with a build directory to allow out of source builds.

I just tested it by : 
- having ```let g:clang_auto_user_options = 'build/compile_commands.json, .clang_complete, path'``` in my .vimrc.
- cd to ${ROOT}/src
- launch vim aFile.cpp
- echo g:clang_compilation_database
The result was what I expected : ${ROOT}/build (this is where I make the project, so this is where the compilation database is located.)

If this is okay, I'll also edit the documentation accordingly before the merge.