### PR TITLE
fixed deprecation warning t.isAlive

### DIFF
--- a/plugin/libclang.py
+++ b/plugin/libclang.py
@@ -517,7 +517,7 @@ def getCurrentCompletions(base):
   t = CompleteThread(line, column, getCurrentFile(), vim.current.buffer.name,
                      params, timer)
   t.start()
-  while t.isAlive():
+  while t.is_alive():
     t.join(0.01)
     cancel = int(vim.eval('complete_check()'))
     if cancel != 0:


### PR DESCRIPTION
replaced the deprecated t.isAlive() with t.is_alive()