### PR TITLE
Fixed UltiSnips py3 after python usage (compat)

### DIFF
--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -189,6 +189,7 @@ function! s:ClangCompleteInit()
   if g:clang_make_default_keymappings == 1
     inoremap <expr> <buffer> <C-X><C-U> <SID>LaunchCompletion()
     inoremap <expr> <buffer> . <SID>CompleteDot()
+    inoremap <expr> <buffer> _ <SID>CompleteUL()
     inoremap <expr> <buffer> > <SID>CompleteArrow()
     inoremap <expr> <buffer> : <SID>CompleteColon()
     execute "nnoremap <buffer> <silent> " . g:clang_jumpto_declaration_key . " :call <SID>GotoDeclaration(0)<CR><Esc>"
@@ -607,6 +608,13 @@ function! s:LaunchCompletion()
     endif
   endif
   return l:result
+endfunction
+
+function! s:CompleteUL()
+  if g:clang_complete_auto == 1
+    return '_' . s:LaunchCompletion()
+  endif
+  return '_'
 endfunction
 
 function! s:CompleteDot()

--- a/plugin/clang_complete.vim
+++ b/plugin/clang_complete.vim
@@ -26,12 +26,12 @@ let s:plugin_path = escape(expand('<sfile>:p:h'), '\')
 " Older versions of Vim can't check if a map was made with <expr>
 let s:use_maparg = v:version > 703 || (v:version == 703 && has('patch32'))
 
-if has('python')
+if has('python3')
+  let s:py_cmd = 'py3'
+  let s:pyfile_cmd = 'py3file'
+elseif has('python')
   let s:py_cmd = 'python'
   let s:pyfile_cmd = 'pyfile'
-elseif has('python3')
-  let s:py_cmd = 'python3'
-  let s:pyfile_cmd = 'py3file'
 endif
 
 function! s:ClangCompleteInit()
@@ -282,7 +282,7 @@ function! s:processFilename(filename, root)
   if matchstr(a:filename, '\C^[''"\\]\=/') != ''
     let l:filename = a:filename
   " Handle Windows absolute path
-  elseif s:isWindows() 
+  elseif s:isWindows()
        \ && matchstr(a:filename, '\C^"\=[a-zA-Z]:[/\\]') != ''
     let l:filename = a:filename
   " Convert relative path to absolute path
@@ -304,7 +304,7 @@ function! s:processFilename(filename, root)
       let l:filename = shellescape(a:root) . a:filename
     endif
   endif
-  
+
   return l:filename
 endfunction
 


### PR DESCRIPTION
This fixes two issues:
- Standard `python` is used even if installed along `python3`
- Compatibility with other plugins such as UltiSnips using `py3` vs `python` causing vim errors on every keystroke