### PR TITLE
update example llvm version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,8 @@ $ vim clang_complete.vmb -c 'so %' -c 'q'
   the file itself, example:
 
 ```vim
- " path to directory where library can be found
- let g:clang_library_path='/usr/lib/llvm-3.8/lib'
- " or path directly to the library file
- let g:clang_library_path='/usr/lib64/libclang.so.3.8'
+ " provide path directly to the library file
+ let g:clang_library_path='/usr/lib/llvm-14/lib/libclang-14.so.1'
 ```
 
 - Compiler options can be configured in a `.clang_complete` file in each project


### PR DESCRIPTION
in the README.md, 
on the example of libclang path folder, says that I can provide only folder path but that doesn't work since it only accepts version llvm version 3.8, it is a bit confusing and took me a while to figure out that you need to include file path for whatever libclang version you have installed.

It makes more sense to just mention that you should include file-path.  If you only put folder path, then it only works for llvm-3.8 and not llvm-14.

Thank you.