### PR TITLE
fix completion failure on utf-8 multi-byte characters.

### DIFF
--- a/plugin/clang/cindex.py
+++ b/plugin/clang/cindex.py
@@ -2025,7 +2025,7 @@ class TranslationUnit(ClangObject):
 
                 unsaved_array[i].name = encode(name)
                 unsaved_array[i].contents = encode(contents)
-                unsaved_array[i].length = len(contents)
+                unsaved_array[i].length = len(unsaved_array[i].contents)
 
         ptr = conf.lib.clang_parseTranslationUnit(index, encode(filename),
                                     args_array, len(args), unsaved_array,
@@ -2207,7 +2207,7 @@ class TranslationUnit(ClangObject):
                     raise TypeError('Unexpected unsaved file contents.')
                 unsaved_files_array[i].name = encode(name)
                 unsaved_files_array[i].contents = encode(value)
-                unsaved_files_array[i].length = len(value)
+                unsaved_files_array[i].length = len(unsaved_files_array[i].contents)
         ptr = conf.lib.clang_reparseTranslationUnit(self, len(unsaved_files),
                 unsaved_files_array, options)
 
@@ -2271,7 +2271,7 @@ class TranslationUnit(ClangObject):
                     raise TypeError('Unexpected unsaved file contents.')
                 unsaved_files_array[i].name = encode(name)
                 unsaved_files_array[i].contents = encode(value)
-                unsaved_files_array[i].length = len(value)
+                unsaved_files_array[i].length = len(unsaved_files_array[i].contents)
         ptr = conf.lib.clang_codeCompleteAt(self, encode(path), line, column,
                 unsaved_files_array, len(unsaved_files), options)
         if ptr:


### PR DESCRIPTION
This patch fixes completion failure on source files containing 3-byte utf-8 characters.
for example, save as example.cpp:

#include <iostream>

// 张九龄《望月怀远》
// 海上生明月，天涯共此时。
// 情人怨遥夜，竟夕起相思。
// 灭烛怜光满，披衣觉露滋。
// 不堪盈手赠，还寝梦佳期。

int main(void)
{
    std::cout << "completion failure";
    return 0;
}


